### PR TITLE
Version panel - display version label value

### DIFF
--- a/dashboard/prometheus2-dashboard.json
+++ b/dashboard/prometheus2-dashboard.json
@@ -357,7 +357,8 @@
               "format": "table",
               "instant": true,
               "intervalFactor": 2,
-              "refId": "A"
+              "refId": "A",
+              "legendFormat": "{{version}}"
             }
           ],
           "thresholds": "",
@@ -371,7 +372,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "name"
         },
         {
           "cacheTimeout": null,


### PR DESCRIPTION
Small change to display the version correctly, currently it shows the value of the metric which is always `1`.

This change shows the value of the label `version` which is what we want to see.